### PR TITLE
Introduce initial draft.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:524a7410eed8e341de4388f261d32db80c20bbd098cde577df0aa8729e92ff7b"
+  name = "github.com/freerware/work-it"
+  packages = ["mocks"]
+  pruneopts = "UT"
+  revision = "0ebe00256c4c8e862415b32b2a12ac8acd33fcf3"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -82,6 +90,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DATA-DOG/go-sqlmock",
+    "github.com/freerware/work-it/mocks",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/suite",
     "go.uber.org/multierr",

--- a/best_effort_unit.go
+++ b/best_effort_unit.go
@@ -1,0 +1,179 @@
+package work
+
+import (
+	"fmt"
+
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+type bestEffortUnit struct {
+	unit
+
+	successfulInserts map[TypeName][]interface{}
+	successfulUpdates map[TypeName][]interface{}
+	successfulDeletes map[TypeName][]interface{}
+
+	successfulInsertCount int
+	successfulUpdateCount int
+	successfulDeleteCount int
+}
+
+// NewBestEffortUnit constructs a work unit that when faced
+// with adversity, attempts rollback a single time.
+func NewBestEffortUnit(parameters UnitParameters) Unit {
+	u := bestEffortUnit{
+		unit:              newUnit(parameters),
+		successfulInserts: make(map[TypeName][]interface{}),
+		successfulUpdates: make(map[TypeName][]interface{}),
+		successfulDeletes: make(map[TypeName][]interface{}),
+	}
+	return &u
+}
+
+func (u *bestEffortUnit) rollbackInserts() error {
+
+	//delete successfully inserted entities.
+	u.logDebug("attempting to rollback inserted entities",
+		zap.Int("count", u.successfulInsertCount))
+	for typeName, inserts := range u.successfulInserts {
+		if err := u.deleters[typeName].Delete(inserts...); err != nil {
+			u.logError(err.Error(), zap.String("typeName", typeName.String()))
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *bestEffortUnit) rollbackUpdates() error {
+
+	//reapply previously registered state for the entities.
+	u.logDebug("attempting to rollback updated entities",
+		zap.Int("count", u.successfulUpdateCount))
+	for typeName, r := range u.registered {
+		if err := u.updaters[typeName].Update(r...); err != nil {
+			u.logError(err.Error(), zap.String("typeName", typeName.String()))
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *bestEffortUnit) rollbackDeletes() error {
+
+	//reinsert successfully deleted entities.
+	u.logDebug("attempting to rollback deleted entities",
+		zap.Int("count", u.successfulDeleteCount))
+	for typeName, deletes := range u.successfulDeletes {
+		if err := u.inserters[typeName].Insert(deletes...); err != nil {
+			u.logError(err.Error(), zap.String("typeName", typeName.String()))
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *bestEffortUnit) rollback() error {
+	if err := u.rollbackDeletes(); err != nil {
+		return err
+	}
+
+	if err := u.rollbackUpdates(); err != nil {
+		return err
+	}
+
+	return u.rollbackInserts()
+}
+
+func (u *bestEffortUnit) applyInserts() error {
+
+	u.logDebug("attempting to insert entities", zap.Int("count", len(u.additions)))
+	for typeName, additions := range u.additions {
+		if err := u.inserters[typeName].Insert(additions...); err != nil {
+			err = multierr.Combine(err, u.rollback())
+			u.logError(err.Error(), zap.String("typeName", typeName.String()))
+			return err
+		}
+		if _, ok := u.successfulInserts[typeName]; !ok {
+			u.successfulInserts[typeName] = []interface{}{}
+		}
+		u.successfulInserts[typeName] =
+			append(u.successfulInserts[typeName], additions...)
+		u.successfulInsertCount = u.successfulInsertCount + len(additions)
+	}
+	return nil
+}
+
+func (u *bestEffortUnit) applyUpdates() error {
+
+	u.logDebug("attempting to update entities", zap.Int("count", len(u.alterations)))
+	for typeName, alterations := range u.alterations {
+		if err := u.updaters[typeName].Update(alterations...); err != nil {
+			err = multierr.Combine(err, u.rollback())
+			u.logError(err.Error(), zap.String("typeName", typeName.String()))
+			return err
+		}
+		if _, ok := u.successfulUpdates[typeName]; !ok {
+			u.successfulUpdates[typeName] = []interface{}{}
+		}
+		u.successfulUpdates[typeName] =
+			append(u.successfulUpdates[typeName], alterations...)
+		u.successfulUpdateCount = u.successfulUpdateCount + len(alterations)
+	}
+	return nil
+}
+
+func (u *bestEffortUnit) applyDeletes() error {
+
+	u.logDebug("attempting to remove entities", zap.Int("count", len(u.removals)))
+	for typeName, removals := range u.removals {
+		if err := u.deleters[typeName].Delete(removals...); err != nil {
+			err = multierr.Combine(err, u.rollback())
+			u.logError(err.Error(), zap.String("typeName", typeName.String()))
+			return err
+		}
+		if _, ok := u.successfulDeletes[typeName]; !ok {
+			u.successfulDeletes[typeName] = []interface{}{}
+		}
+		u.successfulDeletes[typeName] =
+			append(u.successfulDeletes[typeName], removals...)
+		u.successfulDeleteCount = u.successfulDeleteCount + len(removals)
+	}
+	return nil
+}
+
+func (u *bestEffortUnit) Save() (err error) {
+
+	//rollback if there is a panic.
+	defer func() {
+		if r := recover(); r != nil {
+			err = multierr.Combine(
+				fmt.Errorf("panic: unable to save work unit\n%v", r), u.rollback())
+			u.logError("panic: unable to save work unit",
+				zap.String("panic", fmt.Sprintf("%v", r)))
+		}
+	}()
+
+	//insert newly added entities.
+	if err = u.applyInserts(); err != nil {
+		return
+	}
+
+	//update altered entities.
+	if err = u.applyUpdates(); err != nil {
+		return
+	}
+
+	//delete removed entities.
+	if err = u.applyDeletes(); err != nil {
+		return
+	}
+
+	totalCount := u.additionCount + u.alterationCount + u.removalCount
+	u.logInfo("successfully saved unit",
+		zap.Int("insertCount", u.additionCount),
+		zap.Int("updateCount", u.alterationCount),
+		zap.Int("deleteCount", u.removalCount),
+		zap.Int("totalCount", totalCount))
+	return
+}

--- a/best_effort_unit_test.go
+++ b/best_effort_unit_test.go
@@ -1,0 +1,506 @@
+package work
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/freerware/work-it/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+type BestEffortUnitTestSuite struct {
+	suite.Suite
+
+	// system under test.
+	sut Unit
+
+	// mocks.
+	inserters map[TypeName]*mocks.Inserter
+	updaters  map[TypeName]*mocks.Updater
+	deleters  map[TypeName]*mocks.Deleter
+}
+
+func TestBestEffortUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(BestEffortUnitTestSuite))
+}
+
+func (s *BestEffortUnitTestSuite) SetupTest() {
+
+	// test entities.
+	foo := Foo{ID: 28}
+	fooTypeName := TypeNameOf(foo)
+	bar := Bar{ID: "28"}
+	barTypeName := TypeNameOf(bar)
+
+	// initialize mocks.
+	s.inserters = make(map[TypeName]*mocks.Inserter)
+	s.inserters[fooTypeName] = &mocks.Inserter{}
+	s.inserters[barTypeName] = &mocks.Inserter{}
+	s.updaters = make(map[TypeName]*mocks.Updater)
+	s.updaters[fooTypeName] = &mocks.Updater{}
+	s.updaters[barTypeName] = &mocks.Updater{}
+	s.deleters = make(map[TypeName]*mocks.Deleter)
+	s.deleters[fooTypeName] = &mocks.Deleter{}
+	s.deleters[barTypeName] = &mocks.Deleter{}
+
+	// construct SUT.
+	i := make(map[TypeName]Inserter)
+	for t, m := range s.inserters {
+		i[t] = m
+	}
+	u := make(map[TypeName]Updater)
+	for t, m := range s.updaters {
+		u[t] = m
+	}
+	d := make(map[TypeName]Deleter)
+	for t, m := range s.deleters {
+		d[t] = m
+	}
+
+	l, _ := zap.NewDevelopment()
+	params := UnitParameters{
+		Inserters: i,
+		Updaters:  u,
+		Deleters:  d,
+		Logger:    l,
+	}
+	s.sut = NewBestEffortUnit(params)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_InserterError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(err)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(err)
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(nil)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_InserterAndRollbackError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(err)
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(err)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(err)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(err)
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(nil)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_UpdaterAndRollbackError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(err)
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(err)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(nil)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_DeleterError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
+	s.deleters[fooType].On("Delete", removedEntities[0]).Return(err)
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(nil)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_DeleterAndRollbackError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
+	s.deleters[fooType].On("Delete", removedEntities[0]).Return(err)
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(err)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(nil)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_Panic() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
+	s.deleters[fooType].
+		On("Delete", removedEntities[0]).
+		Return().Run(func(args mock.Arguments) { panic("whoa") })
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(nil)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save_PanicAndRollbackError() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	registeredEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+		Foo{ID: 1111},
+	}
+	s.sut.Register(registeredEntities...)
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	err := errors.New("whoa")
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
+	s.deleters[fooType].
+		On("Delete", removedEntities[0]).
+		Return().Run(func(args mock.Arguments) { panic("whoa") })
+
+	// arrange - rollback invocations.
+	s.inserters[fooType].On("Insert", removedEntities[0]).Return(nil)
+	s.deleters[fooType].On("Delete", addedEntities[0]).Return(nil)
+	s.deleters[barType].On("Delete", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On(
+		"Update", registeredEntities[0], registeredEntities[2]).Return(nil)
+	s.updaters[barType].On(
+		"Update", registeredEntities[1]).Return(err)
+
+	// action.
+	err = s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.Error(err)
+}
+
+func (s *BestEffortUnitTestSuite) TestBestEffortUnit_Save() {
+
+	// arrange.
+	fooType := TypeNameOf(Foo{})
+	barType := TypeNameOf(Bar{})
+	addedEntities := []interface{}{
+		Foo{ID: 28},
+		Bar{ID: "28"},
+	}
+	updatedEntities := []interface{}{
+		Foo{ID: 1992},
+		Bar{ID: "1992"},
+	}
+	removedEntities := []interface{}{
+		Foo{ID: 2},
+	}
+	addError := s.sut.Add(addedEntities...)
+	alterError := s.sut.Alter(updatedEntities...)
+	removeError := s.sut.Remove(removedEntities...)
+	s.inserters[fooType].On("Insert", addedEntities[0]).Return(nil)
+	s.inserters[barType].On("Insert", addedEntities[1]).Return(nil)
+	s.updaters[fooType].On("Update", updatedEntities[0]).Return(nil)
+	s.updaters[barType].On("Update", updatedEntities[1]).Return(nil)
+	s.deleters[fooType].On("Delete", removedEntities[0]).Return(nil)
+
+	// action.
+	err := s.sut.Save()
+
+	// assert.
+	s.Require().NoError(addError)
+	s.Require().NoError(alterError)
+	s.Require().NoError(removeError)
+	s.NoError(err)
+}
+
+func (s *BestEffortUnitTestSuite) TearDownTest() {
+	s.sut = nil
+}

--- a/sql_unit_test.go
+++ b/sql_unit_test.go
@@ -134,11 +134,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_InserterError() {
 	s._db.ExpectRollback()
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(errors.New("whoa"))
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(errors.New("whoa"))
 
 	// action.
@@ -175,11 +175,11 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_InserterAndRollbackError() {
 	s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(errors.New("whoa"))
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(errors.New("whoa"))
 
 	// action.
@@ -215,19 +215,19 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_UpdaterError() {
 	s._db.ExpectRollback()
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(errors.New("whoa"))
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(errors.New("whoa"))
 
 	// action.
@@ -264,19 +264,19 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_UpdaterAndRollbackError() {
 	s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(errors.New("whoa"))
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(errors.New("whoa"))
 
 	// action.
@@ -313,23 +313,23 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_DeleterError() {
 	s._db.ExpectRollback()
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(nil)
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(nil)
 	s.deleters[fooType].On(
 		"Delete",
-		[]interface{}{removedEntities[0]},
+		removedEntities[0],
 	).Return(errors.New("whoa"))
 
 	// action.
@@ -366,23 +366,23 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_DeleterAndRollbackError() {
 	s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(nil)
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(nil)
 	s.deleters[fooType].On(
 		"Delete",
-		[]interface{}{removedEntities[0]},
+		removedEntities[0],
 	).Return(errors.New("whoa"))
 
 	// action.
@@ -419,23 +419,23 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_Panic() {
 	s._db.ExpectRollback().WillReturnError(errors.New("whoa"))
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(nil)
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(nil)
 	s.deleters[fooType].On(
 		"Delete",
-		[]interface{}{removedEntities[0]},
+		removedEntities[0],
 	).Return().Run(func(args mock.Arguments) { panic("whoa") })
 
 	// action.
@@ -472,23 +472,23 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_PanicAndRollbackError() {
 	s._db.ExpectRollback()
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(nil)
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(nil)
 	s.deleters[fooType].On(
 		"Delete",
-		[]interface{}{removedEntities[0]},
+		removedEntities[0],
 	).Return().Run(func(args mock.Arguments) { panic("whoa") })
 
 	// action.
@@ -525,23 +525,23 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save_CommitError() {
 	s._db.ExpectCommit().WillReturnError(errors.New("whoa"))
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(nil)
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(nil)
 	s.deleters[fooType].On(
 		"Delete",
-		[]interface{}{removedEntities[0]},
+		removedEntities[0],
 	).Return(nil)
 
 	// action.
@@ -578,23 +578,23 @@ func (s *SQLUnitTestSuite) TestSQLUnit_Save() {
 	s._db.ExpectCommit()
 	s.inserters[fooType].On(
 		"Insert",
-		[]interface{}{addedEntities[0]},
+		addedEntities[0],
 	).Return(nil)
 	s.inserters[barType].On(
 		"Insert",
-		[]interface{}{addedEntities[1]},
+		addedEntities[1],
 	).Return(nil)
 	s.updaters[fooType].On(
 		"Update",
-		[]interface{}{updatedEntities[0]},
+		updatedEntities[0],
 	).Return(nil)
 	s.updaters[barType].On(
 		"Update",
-		[]interface{}{updatedEntities[1]},
+		updatedEntities[1],
 	).Return(nil)
 	s.deleters[fooType].On(
 		"Delete",
-		[]interface{}{removedEntities[0]},
+		removedEntities[0],
 	).Return(nil)
 
 	// action.


### PR DESCRIPTION
## Overview

- Fixes core aspects of the library.
  - For example, slices were being passed into `Inserter`, `Updater`, `Deleter` instead of using the spread operator (`...`).
- Introduces `BestEffortUnit`.
  - Name is not my favorite...open to suggestions here.
- Introduces `Register(...)` method on `Unit` to accommodate proper rollback behavior for non-ACID units.
- Properly defines vanity import to match intended package naming.